### PR TITLE
ZTF found objects query

### DIFF
--- a/src/controllers/ztf_search.py
+++ b/src/controllers/ztf_search.py
@@ -9,7 +9,7 @@ import logging
 import flask_restplus as FRP
 from flask import request, jsonify
 from flask.wrappers import Response
-from services.query_all_ztf_data import query_all_ztf_data
+from services.query_ztf_data import query_ztf_found_data
 
 
 API = FRP.Namespace(
@@ -21,31 +21,33 @@ API = FRP.Namespace(
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-@API.route("/")
+@API.route("/found")
 class ZTF(FRP.Resource):
-    """Controller class for ZTF rows"""
+    """Controller class for ZTF found database rows"""
 
-    @API.doc('--ztf--')
+    @API.doc('--ztf/found--')
+    @API.param('objid', description='Optional. Search for this object id.', _in='query')
     @API.param('end', description='Optional. Paginated ending index.', _in='query')
     @API.param('start', description='Optional. Paginated starting index.', _in='query')
     @FRP.cors.crossdomain(origin='*')
     def get(self: 'ZTF') -> Response:
-        """Returns ZTF row requests"""
+        """Returns ZTF found database row requests"""
 
         # Extract params from URL
+        objid: int = request.args.get('objid', 50, int)
         start: int = request.args.get('start', 0, int)
         end: int = request.args.get('end', 50, int)
 
         # Pass params to data-provider-service
-        all_ztf_data = query_all_ztf_data(start, end)
+        found_ztf_data = query_ztf_found_data(start, end, objid=objid)
 
         # Package retrieved data as response json
         res: Response = jsonify(
             {
                 "start": start,
                 "end": end,
-                "data": all_ztf_data,
-                "total": len(all_ztf_data)
+                "data": found_ztf_data,
+                "total": len(found_ztf_data)
             }
         )
         res.status_code = 200

--- a/src/controllers/ztf_search.py
+++ b/src/controllers/ztf_search.py
@@ -34,7 +34,7 @@ class ZTF(FRP.Resource):
         """Returns ZTF found database row requests"""
 
         # Extract params from URL
-        objid: int = request.args.get('objid', 50, int)
+        objid: int = request.args.get('objid', 0, int)
         start: int = request.args.get('start', 0, int)
         end: int = request.args.get('end', 50, int)
 
@@ -46,6 +46,7 @@ class ZTF(FRP.Resource):
             {
                 "start": start,
                 "end": end,
+                "objid": objid,
                 "data": found_ztf_data,
                 "total": len(found_ztf_data)
             }

--- a/src/services/query_ztf_data.py
+++ b/src/services/query_ztf_data.py
@@ -1,0 +1,27 @@
+'''Query DB for ZTF data'''
+
+from typing import Any, Sequence
+# from models.models import t_ztf_found as ZtfFound
+from models.models import Ztf, Found
+from .database_provider import DATA_PROVIDER_SESSION
+
+
+def query_ztf_found_data(start_row: int = 0, end_row: int = -1, objid: int = -1) -> Any:
+    '''Query DB for ZTF found data'''
+    found_ztf_data: Any  # Sequence[ZtfFound]
+
+    found_ztf_data = (DATA_PROVIDER_SESSION
+                      .query(Found)
+                      .join(Ztf, Found.obsid == Ztf.obsid))
+
+    if objid > 0:
+        (found_ztf_data
+         .filter(Found.objid == objid)
+         .order_by(Found.foundid))
+
+    if end_row == -1:
+        found_ztf_data.limit(500)
+    else:
+        found_ztf_data.offset(start_row).limit(end_row - start_row)
+
+    return [ztf_row.serialize() for (ztf_row) in found_ztf_data]

--- a/src/services/query_ztf_data.py
+++ b/src/services/query_ztf_data.py
@@ -1,27 +1,112 @@
 '''Query DB for ZTF data'''
 
-from typing import Any, Sequence
-# from models.models import t_ztf_found as ZtfFound
+from typing import Any, List, Dict
+from decimal import Decimal
 from models.models import Ztf, Found
 from .database_provider import DATA_PROVIDER_SESSION
 
 
 def query_ztf_found_data(start_row: int = 0, end_row: int = -1, objid: int = -1) -> Any:
     '''Query DB for ZTF found data'''
-    found_ztf_data: Any  # Sequence[ZtfFound]
+    found_ztf_data: List[Any]
 
-    found_ztf_data = (DATA_PROVIDER_SESSION
-                      .query(Found)
-                      .join(Ztf, Found.obsid == Ztf.obsid))
+    found_ztf_data = (
+        DATA_PROVIDER_SESSION
+        .query(
+            Found.foundid,
+            Found.objid,
+            Found.obsjd,
+            Found.ra,
+            Found.dec,
+            Found.dra,
+            Found.ddec,
+            Found.ra3sig,
+            Found.dec3sig,
+            Found.vmag,
+            Found.rh,
+            Found.rdot,
+            Found.delta,
+            Found.phase,
+            Found.selong,
+            Found.sangle,
+            Found.vangle,
+            Found.trueanomaly,
+            Found.tmtp,
+            Ztf.pid,
+            Ztf.obsdate,
+            Ztf.infobits,
+            Ztf.field,
+            Ztf.ccdid,
+            Ztf.qid,
+            Ztf.rcid,
+            Ztf.fid,
+            Ztf.filtercode,
+            Ztf.expid,
+            Ztf.filefracday,
+            Ztf.seeing,
+            Ztf.airmass,
+            Ztf.moonillf,
+            Ztf.maglimit
+        )
+        .join(Ztf, Found.obsid == Ztf.obsid)
+    )
 
     if objid > 0:
-        (found_ztf_data
-         .filter(Found.objid == objid)
-         .order_by(Found.foundid))
+        found_ztf_data = found_ztf_data.filter(Found.objid == objid)
 
-    if end_row == -1:
-        found_ztf_data.limit(500)
-    else:
-        found_ztf_data.offset(start_row).limit(end_row - start_row)
+    found_ztf_data = (
+        found_ztf_data
+        .offset(start_row)
+        .limit(500 if end_row == -1 else end_row - start_row)
+    )
 
-    return [ztf_row.serialize() for (ztf_row) in found_ztf_data]
+    serialized_row: Dict[Any] = {}
+    all_serialized_rows: List[dict] = []
+    for row in found_ztf_data:
+        serialized_row = {
+            "foundid": row.foundid,
+            "objid": row.objid,
+            "obsjd": row.obsjd,
+            "ra": row.ra,
+            "dec": row.dec,
+            "dra": row.dra,
+            "ddec": row.ddec,
+            "ra3sig": row.ra3sig,
+            "dec3sig": row.dec3sig,
+            "vmag": row.vmag,
+            "rh": row.rh,
+            "rdot": row.rdot,
+            "delta": row.delta,
+            "phase": row.phase,
+            "selong": row.selong,
+            "sangle": row.sangle,
+            "vangle": row.vangle,
+            "trueanomaly": row.trueanomaly,
+            "tmtp": row.tmtp,
+            "pid": row.pid,
+            "obsdate": row.obsdate,
+            "infobits": row.infobits,
+            "field": row.field,
+            "ccdid": row.ccdid,
+            "qid": row.qid,
+            "rcid": row.rcid,
+            "fid": row.fid,
+            "filtercode": row.filtercode,
+            "expid": row.expid,
+            "filefracday": row.filefracday,
+            "seeing": row.seeing,
+            "airmass": row.airmass,
+            "moonillf": row.moonillf,
+            "maglimit": row.maglimit
+        }
+        # Convert items in binary row to tpython data structures
+        for a in serialized_row:
+            if isinstance(serialized_row[a], Decimal):
+                serialized_row[a] = float(serialized_row[a])
+            elif isinstance(serialized_row[a], int):
+                serialized_row[a] = int(serialized_row[a])
+            else:
+                serialized_row[a] = str(serialized_row[a])
+        all_serialized_rows.append(serialized_row)
+
+    return all_serialized_rows


### PR DESCRIPTION
Removed the `/ztf` route and added `/ztf/found` for found object queries.  The object id is optional, without all found objects are returned.