### PR TITLE
Bug fix missing archive_url in ztf/found query.

### DIFF
--- a/src/models/ztf.py
+++ b/src/models/ztf.py
@@ -324,7 +324,7 @@ class App:
             description='magnitude limit'
         ),
         "archive_url": FormattedStringOrNone(
-            ZTF_CUTOUT_BASE_URL + '{archivefile}',
+            '/'.join((ZTF_CUTOUT_BASE_URL, '{ZtfCutout.archivefile}')),
             description='FITS cutout from local archive'
         ),
         "irsa_sci_url": fields.FormattedString(


### PR DESCRIPTION
Missing table name `ZtfCutout` in reference to `archivefile`.