### PR TITLE
Fix formattedstringornone crash

### DIFF
--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -41,7 +41,7 @@ REST_PLUS_APIS = Api(
 REST_PLUS_APIS.add_namespace(ns0)
 REST_PLUS_APIS.add_namespace(ns1)
 REST_PLUS_APIS.add_namespace(ns2)
-REST_PLUS_APIS.add_namespace(ns3        )
+REST_PLUS_APIS.add_namespace(ns3)
 
 # Add error handlers:
 @REST_PLUS_APIS.errorhandler

--- a/src/util.py
+++ b/src/util.py
@@ -18,5 +18,5 @@ class FormattedStringOrNone(fields.FormattedString):
     def output(self, key, obj, **kwargs):
         try:
             return super().output(key, obj, **kwargs)
-        except KeyError:
+        except (KeyError, AttributeError):
             return None


### PR DESCRIPTION
If ZtfCutouts cannot be joined to found query, it is `None`, so FormattedStringOrNone('{ZtfCutout.archivefile}') fails with AttributeError.  Catch it.