### PR TITLE
Use relative import.

### DIFF
--- a/src/tasks/worker.py
+++ b/src/tasks/worker.py
@@ -4,7 +4,7 @@
 
 from typing import List
 from redis import from_url, Redis
-from tasks import RQueues
+from . import RQueues
 from rq import Worker, Queue, Connection
 from env import ENV
 


### PR DESCRIPTION
Solves:

Traceback (most recent call last):
  File "src/tasks/worker.py", line 7, in <module>
    from tasks import RQueues
ModuleNotFoundError: No module named 'tasks'