### PR TITLE
Document results

### DIFF
--- a/src/controllers/caught.py
+++ b/src/controllers/caught.py
@@ -9,7 +9,7 @@ from typing import Dict, Union
 import flask_restplus as FRP
 from flask import Response, jsonify
 
-from models.caught import App
+from models.caught import App, COLUMN_LABELS
 import services.caught as service
 from util import jsonify_output
 
@@ -24,21 +24,20 @@ class Caught(FRP.Resource):
 
     @API.doc('--caught/--')
     @FRP.cors.crossdomain(origin='*')
+    @jsonify_output
+    @API.marshal_with(App.caught_model)
     def get(self: 'Caught', job_id: Union[str, uuid.UUID]) -> Response:
         """Caught moving target data."""
 
         # validate job_id format
         job_id = uuid.UUID(str(job_id), version=4)
 
-        # retrieve data
         data: dict = service.caught(job_id)
-
-        response: Response = jsonify({
+        response: Dict[str, Union[str, dict, int]] = {
             "count": len(data),
             "job_id": job_id.hex,
-            "data": FRP.marshal(data, App.caught_data)
-        })
-        response.status_code = 200
+            "data": data
+        }
         return response
 
 
@@ -49,8 +48,7 @@ class CaughtLabels(FRP.Resource):
     @API.doc('--caught/labels--')
     @FRP.cors.crossdomain(origin='*')
     @jsonify_output
-    def get(self: 'CaughtLabels') -> Dict[str, Dict[str, str]]:
+    def get(self: 'CaughtLabels') -> Dict[str, Dict[str, Union[str, int]]]:
         """Caught moving object table labels."""
-        data: Dict[str, Dict[str, str]] = (
-            service.column_labels('/'))
+        data: Dict[str, Dict[str, Union[str, int]]] = COLUMN_LABELS['/']
         return data

--- a/src/controllers/query.py
+++ b/src/controllers/query.py
@@ -40,6 +40,8 @@ class Query(FRP.Resource):
         description='Return cached results, if available.'
     )
     @FRP.cors.crossdomain(origin='*')
+    @jsonify_output
+    @API.marshal_with(App.query_model)
     def get(self: 'Query') -> Response:
         """Query for moving target."""
         from . import URL_PREFIX    # avoid circular dependency
@@ -57,12 +59,11 @@ class Query(FRP.Resource):
         total_jobs = len(queue.jobs)
 
         # Build immediate response
-        response: Response
+        response: Dict[str, Union[str, Dict[str, Union[str, bool]]]]
         if total_jobs > 100:
-            response = jsonify({
+            response = {
                 "message": "Error: queue is full."
-            })
-            response.status_code = 200
+            }
         else:
             # unique job ID
             job_id: uuid.UUID = uuid.uuid4()
@@ -71,7 +72,7 @@ class Query(FRP.Resource):
                 request.url_root.strip('/'), URL_PREFIX.strip('/'),
                 job_id.hex)
 
-            payload: Dict[str, Union[Dict[str, Union[str, bool]], str]] = {
+            response = {
                 "message": "",
                 "query": query,
                 "job_id": job_id.hex,
@@ -89,7 +90,7 @@ class Query(FRP.Resource):
                 service.query(query['target'], job_id,
                               source=query['source'], cached=True)
 
-                payload['message'] = (
+                response['message'] = (
                     'Cached query.  Retrieve data from results URL.'
                 )
             else:
@@ -98,26 +99,9 @@ class Query(FRP.Resource):
                               query['source'], query['cached'], job_id,
                               job_id=job_id.hex)
 
-                payload['message'] = (
+                response['message'] = (
                     'Enqueued search.  Listen to event stream until job'
                     ' completed, then retrieve data from results URL.'
                 )
 
-            response = jsonify(payload)
-            response.status_code = 200
-
         return response
-
-
-@API.route("/moving/labels")
-class QueryMovingLabels(FRP.Resource):
-    """Controller for query caught moving object column labels."""
-
-    @API.doc('--query/moving/labels--')
-    @FRP.cors.crossdomain(origin='*')
-    @jsonify_output
-    def get(self: 'QueryMovingLabels') -> Dict[str, Dict[str, str]]:
-        """Query caught moving object table labels."""
-        data: Dict[str, Dict[str, str]] = (
-            service.column_labels('/moving'))
-        return data

--- a/src/models/caught.py
+++ b/src/models/caught.py
@@ -125,9 +125,20 @@ class App:
         ),
     })
 
+    caught_model: Model = api.model('Caught', {
+        'count': fields.Integer(
+            description=("Number of observations that caught the target's"
+                         " ephemeris position")
+        ),
+        'job_id': fields.String(
+            description='Unique job ID of results'
+        ),
+        'data': fields.List(fields.Nested(caught_data))
+    })
+
 
 COLUMN_LABELS: Dict[str, Dict[str, Dict[str, Union[str, int]]]] = {
-    '/moving': {
+    '/': {
         'designation': {
             'label': 'Designation',
             'description': 'Object designation'

--- a/src/models/query.py
+++ b/src/models/query.py
@@ -2,7 +2,7 @@
 /query route namespace and data models.
 """
 
-from flask_restplus import Namespace
+from flask_restplus import Namespace, Model, fields
 
 
 class App:
@@ -11,3 +11,18 @@ class App:
         'Catch moving targets',
         path="/query"
     )
+
+    query_model: Model = api.model('QueryMoving', {
+        'message': fields.String(
+            description='Text message for user'
+        ),
+        'query': fields.String(
+            description="User's inputs"
+        ),
+        'job_id': fields.String(
+            description='Unique job ID for retrieving results'
+        ),
+        'results': fields.String(
+            description='URL from which to retrieve results'
+        )
+    })


### PR DESCRIPTION
Swagger documentation now includes /query and /caught data models.

/caught/labels properly returns table labels.