### PR TITLE
Target name testing

### DIFF
--- a/src/controllers/query.py
+++ b/src/controllers/query.py
@@ -101,3 +101,25 @@ class Query(FRP.Resource):
                 )
 
         return response
+
+
+@API.route("/target/<string:name>")
+class TargetName(FRP.Resource):
+    """Controller class for testing target names."""
+
+    @API.doc('--query/target--')
+    @FRP.cors.crossdomain(origin='*')
+    @jsonify_output
+    @API.marshal_with(App.target_name_model)
+    def get(self: 'TargetName', name: str) -> Dict[str, Union[bool, str]]:
+        """Test target name."""
+
+        target_type: str = service.parse_target_name(name)
+        valid: bool = target_type != 'unknown'
+
+        response: Dict[str, Union[str, Union[bool, str]]] = {
+            'name': name,
+            'type': target_type,
+            'valid': valid
+        }
+        return response

--- a/src/models/query.py
+++ b/src/models/query.py
@@ -16,6 +16,10 @@ class App:
         'message': fields.String(
             description='Text message for user'
         ),
+        'queued': fields.Boolean(
+            description=('true if a search has been queued, '
+                         'false if the results are ready')
+        ),
         'query': fields.String(
             description="User's inputs"
         ),
@@ -27,10 +31,16 @@ class App:
         )
     })
 
-    target_name_model: Model = api.model('TargetName', {
+    target_name_model: Model = api.model('QueryTarget', {
         'name': fields.String(description='Input name'),
         'type': fields.String(
-            description='Target type: asteroid, comet, or unknown'
+            description=('Target type: asteroid, comet, '
+                         'interstellar object, or unknown')
         ),
-        'valid': fields.Boolean(description='false if unknown, otherwise true.')
+        'match': fields.String(
+            description='Target type identification was based on this string'
+        ),
+        'valid': fields.Boolean(
+            description='false if unknown, otherwise true.'
+        )
     })

--- a/src/models/query.py
+++ b/src/models/query.py
@@ -26,3 +26,11 @@ class App:
             description='URL from which to retrieve results'
         )
     })
+
+    target_name_model: Model = api.model('TargetName', {
+        'name': fields.String(description='Input name'),
+        'type': fields.String(
+            description='Target type: asteroid, comet, or unknown'
+        ),
+        'valid': fields.Boolean(description='false if unknown, otherwise true.')
+    })

--- a/src/services/query.py
+++ b/src/services/query.py
@@ -3,13 +3,44 @@ Catch a moving target in survey data.
 """
 
 import re
-from typing import List, Any, Optional, Callable
+from typing import List, Any, Optional, Callable, Tuple, Pattern, Match
 import uuid
 
 from sbpy.data.names import Names, TargetNameParseError
 
 from .caught import caught
 from .database_provider import catch_manager
+
+
+class TargetTypePatterns:
+    # developed with some guidance from sbpy code.
+    temporary_designation: str = (
+        '(18|19|20)[0-9][0-9] [A-Z]{1,2}([1-9][0-9]{0,2})?'
+    )
+    name: str = "['`]?[dvA-Z][A-Z]*['`]?[a-z][a-z]*['`]?[^0-9]*"
+    cometary_fragment: str = '-[A-Z]{1,2}'
+
+    cometary: Pattern = re.compile(
+        # all comets start with 123P, 123D, or P/, C/, D/, X/
+        # allow fragments like 73P-B
+        # First check for 99P/2030 A2, then P/2030 A2
+        # This avoids nonsense like 32C/Asdf
+        ('(^([1-9][0-9]*[PD]({frag})?)(/(({temp}({frag})?)))?)|({name})'
+         '|(^[PDCX]/{temp}({frag})?)'
+         )
+        .format(frag=cometary_fragment, temp=temporary_designation,
+                name=name)
+    )
+
+    asteroidal: Pattern = re.compile(
+        '(^\([1-9][0-9]*\)( {name})?)|(^[1-9][0-9]*)|(^{temp})'
+        .format(name=name, temp=temporary_designation)
+    )
+
+    interstellar_object: Pattern = re.compile(
+        '[1-9][0-9]*I((/{name})|(/{temp}))'.format(
+            name=name, temp=temporary_designation)
+    )
 
 
 def query(target: str, job_id: uuid.UUID, source: str,
@@ -78,7 +109,7 @@ def check_cache(target: str, source: str,
     return cached
 
 
-def parse_target_name(name: str) -> str:
+def parse_target_name(name: str) -> Tuple[str, str]:
     """Parse moving target name.
 
 
@@ -91,25 +122,26 @@ def parse_target_name(name: str) -> str:
     Returns
     -------
     target_type : str
-        'asteroid', 'comet', or 'unknown'.
+        'asteroid', 'comet', 'interstellar object', or 'unknown'.
+
+    match : str
+        String that matched the target type format.  Blank for unknown.
 
     """
 
-    parser: Callable
+    pattern: Pattern
+    match: str
     target_type: str
-    if re.match('(^[PCDXA]/)|(^[0-9]+[PD])', name):
-        parser = Names.parse_comet
-        target_type = 'comet'
-    else:
-        parser = Names.parse_asteroid
-        target_type = 'asteroid'
-
-    try:
-        parser(name)
-        if target_type.startswith('A/'):
-            # in sbpy v0.1.1, this parses as a comet but should be asteroid
-            target_type = 'asteroid'
-    except TargetNameParseError:
+    for target_type, pattern in (('comet', TargetTypePatterns.cometary),
+                                 ('asteroid', TargetTypePatterns.asteroidal),
+                                 ('interstellar object',
+                                  TargetTypePatterns.interstellar_object)):
+        m: Union[Match, None] = pattern.match(name)
+        if m is not None:
+            match = m[0]
+            break
+    if m is None:
         target_type = 'unknown'
+        match = ''
 
-    return target_type
+    return target_type, match


### PR DESCRIPTION
New route: query/target?name=STRING to test for valid small body target names.

New return value in query/moving, 'queued', to notify the user if a query needed to be queued and that they should wait for the search to complete.