### PR TITLE
Use sbsearch 1.0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -92,4 +92,4 @@ werkzeug<=0.16.0
 wrapt==1.11.1
 -e git+git://github.com/Small-Bodies-Node/catch.git@v0.3.4#egg=catch
 -e git+git://github.com/NASA-Planetary-Science/sbpy.git@v0.1.1#egg=sbpy
--e git+git://github.com/Small-Bodies-Node/sbsearch.git@v1.0.7#egg=sbsearch
+-e git+git://github.com/Small-Bodies-Node/sbsearch.git@v1.0.9#egg=sbsearch


### PR DESCRIPTION
sbsearch 1.0.9 fixes the orientation of unc_theta when JPL Horizons is used as the ephemeris source.