### PR TITLE
Avoid failures for comets classified as asteroids.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -91,5 +91,5 @@ webencodings==0.5.1
 werkzeug<=0.16.0
 wrapt==1.11.1
 sbpy==0.2
--e git+git://github.com/Small-Bodies-Node/sbsearch.git@v1.0.15#egg=sbsearch
--e git+git://github.com/Small-Bodies-Node/catch.git@v0.4.2#egg=catch
+-e git+git://github.com/Small-Bodies-Node/sbsearch.git@v1.1.2#egg=sbsearch
+-e git+git://github.com/Small-Bodies-Node/catch.git@v0.4.3#egg=catch


### PR DESCRIPTION
Use sbsearch v1.1.2 and catch v0.4.3.